### PR TITLE
addition of type filter when present as a query parameter

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -61,6 +61,7 @@ export class ExtendedHTTPApi {
         app.get('/extended-api/:type', async (req, res) => {
             const limit = req.query.limit || 10;
             const offset = req.query.offset || 0;
+            const transactionType = Number(req.query.type) || -1;
             const type = req.params.type === "accounts" ? "Account" : req.params.type === "transactions" ? "Transaction" : null;
             if (!type) {
                 res.send({
@@ -71,13 +72,21 @@ export class ExtendedHTTPApi {
                     let filters: Array<any> = [];
                     if (req.query.asset) {
                         if (!req.query.contains) {
-                            filters.push({asset_exists: req.query.asset});
+                            const filter: any = { asset_exists: req.query.asset };
+                            if (transactionType > -1){
+                                filter.type = transactionType;
+                            }
+                            filters.push(filter);
                         }
                         if (req.query.contains) {
                             let obj = {};
                             const contains = !isNaN(req.query.contains) ? Number(req.query.contains) : req.query.contains;
                             _.set(obj, req.query.asset, contains);
-                            filters.push({asset_contains: JSON.stringify(obj)});
+                            const filter: any = { asset_contains: JSON.stringify(obj) };
+                            if (transactionType > -1){
+                                filter.type = transactionType;
+                            }
+                            filters.push(filter);
                         }
                     }
 
@@ -126,3 +135,4 @@ export class ExtendedHTTPApi {
         this.logger.info('Cleaned up extended HTTP API successfully');
     }
 };
+


### PR DESCRIPTION
We would love to use the extented-api with multiple properties to filter on without introducing new filters where the OR operator is triggered in the base_entity.js class of the SDK. 

The pull request enables this by adding the type property to all asset filters if present. I can also enable the API to be open for all properties for the Transaction class if it's wanted for next releases.